### PR TITLE
Update versioning to use adopt-info

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: inadyn
-version: 'stable'
-version-script: git -C parts/inadyn/build describe --tags | sed 's/v//'
+adopt-info: inadyn
 summary: Internet Automated Dynamic DNS Client
 description: |
   Inadyn is a small and simple Dynamic DNS, DDNS, client with HTTPS support.
@@ -40,17 +39,19 @@ parts:
     plugin: autotools
     source: https://github.com/troglobit/inadyn.git
     source-type: git
-    override-build: |
+    override-pull: |
+      snapcraftctl pull
       last_committed_tag="$(git describe --tags --abbrev=0)"
-      last_committed_tag_ver="$(echo last_committed_tag | sed 's/v//')"
-      last_released_tag="$(snap info inadyn | awk '$1 == "beta:" { print $2 }')"
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
       # beta, build that tag instead of master.
-      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+      if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
         git fetch
         git checkout "${last_committed_tag}"
+        snapcraftctl set-version "${last_committed_tag#v}"
+      else
+        snapcraftctl set-version "$(git rev-parse --short HEAD)"
       fi
-      snapcraftctl build
     configflags: ['--prefix=/usr', '--sysconfdir=/etc']
     build-packages:
       - libgnutls28-dev


### PR DESCRIPTION
The new script is slightly refined - look into using this:

```bash
snapcraftctl set-version "${last_committed_tag#v}"
```

... elsewhere on other snaps instead of the older style:

```bash
last_committed_tag="$(git describe --tags --abbrev=0)"
last_committed_tag_ver="$(echo last_committed_tag | sed 's/v//')"
```

`${last_committed_tag#v}` strips any leading `v` from the tag name :-)

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>